### PR TITLE
Fix #19: Don't show the 'syntax-error' message for real-time scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-**[0.10.0] 2018-09-08**
+**[0.10.0] 2018-09-12**
 - Fix #7: Support linting inside current Virtualenv
+- Fix #19: Don't show the 'syntax-error' message for real-time scan
 - New: Improved Pylint auto-detection
+- New: Option to install Pylint if missing
 - New: Settings button now opens File | Settings | Pylint
 - New: Minimum compatibility version raised to 163.15529
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ helps enforcing a coding standard and sniffs for some code smells
 ![pylint plugin screenshot](https://github.com/leinardi/pylint-pycharm/blob/master/art/pylint-pycharm.png)
 
 ## Installation steps
-The plugin requires [pylint](https://github.com/PyCQA/pylint) to be installed.
-
 1. In the **Settings/Preferences** dialog (<kbd>CTRL</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>), click **Plugins**. The [Plugins page](https://www.jetbrains.com/help/pycharm/plugins-settings.html) opens.
 2. Click **Browse repositories**.
 3. In the [Browse Repositories dialog](https://www.jetbrains.com/help/pycharm/browse-repositories-dialog.html) that opens, right-click on the plugin named **Pylint** and select **Download and Install**.

--- a/src/main/java/com/leinardi/pycharm/pylint/PylintInspection.java
+++ b/src/main/java/com/leinardi/pycharm/pylint/PylintInspection.java
@@ -48,6 +48,7 @@ public class PylintInspection extends LocalInspectionTool {
 
     private static final Logger LOG = Logger.getInstance(PylintInspection.class);
     private static final List<Problem> NO_PROBLEMS_FOUND = Collections.emptyList();
+    private static final String ERROR_MESSAGE_ID_SYNTAX_ERROR = "E0001";
 
     private PylintPlugin plugin(final Project project) {
         final PylintPlugin pylintPlugin = project.getComponent(PylintPlugin.class);
@@ -85,6 +86,8 @@ public class PylintInspection extends LocalInspectionTool {
             }
             ScanFiles scanFiles = new ScanFiles(plugin, Collections.singletonList(psiFile.getVirtualFile()));
             Map<PsiFile, List<Problem>> map = scanFiles.call();
+            map.values().forEach(problems -> problems.removeIf(problem ->
+                    problem.getMessageId().equals(ERROR_MESSAGE_ID_SYNTAX_ERROR)));
             if (map.isEmpty()) {
                 return NO_PROBLEMS_FOUND;
             }


### PR DESCRIPTION
Closes #19 