### PR TITLE
Fix #30: Exception in Intellij 2018.2.4 with pylint

### DIFF
--- a/src/main/java/com/leinardi/pycharm/pylint/plapi/PylintRunner.java
+++ b/src/main/java/com/leinardi/pycharm/pylint/plapi/PylintRunner.java
@@ -95,7 +95,7 @@ public class PylintRunner {
                     .lines().collect(Collectors.joining("\n"));
             if (!StringUtil.isEmpty(error)) {
                 LOG.info("Command Line string: " + cmd.getCommandLineString());
-                LOG.error("Error while checking Pylint path: " + error);
+                LOG.info("Messages while checking Pylint path: " + error);
             }
             String output = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))
                     .lines().collect(Collectors.joining("\n"));
@@ -211,7 +211,7 @@ public class PylintRunner {
                     .lines().collect(Collectors.joining("\n"));
             if (!StringUtil.isEmpty(error)) {
                 LOG.info("Command Line string: " + cmd.getCommandLineString());
-                LOG.error("Error while detecting Pylint path: " + error);
+                LOG.info("Messages while checking Pylint path: " + error);
             }
             if (process.exitValue() != 0 || !path.isPresent()) {
                 LOG.info("Command Line string: " + cmd.getCommandLineString());


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](/.github/CONTRIBUTING.md) to this project
- [x] I have read [the code of conduct](/.github/CODE_OF_CONDUCT.md) to this project

### Contributor checklist
- [x] I am using the provided [codeStyleConfig.xml](/.idea/codeStyles)
- [x] I have tested my contribution on these versions of PyCharm/IDEA:
 * PyCharm EDU 2018.1.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fix #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
Pylint gives informational messages on standard error, but pylint-pycharm considers any output on standard error to be worth logging at the ERROR level, leading to the behavior described in #30.  This PR changes the log level to INFO (and also the log prefix) so that such messages are still available for debugging but do not provoke complaints from PyCharm et al.

### Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

### Related Issue

Closes #30
